### PR TITLE
Update vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 $script = <<SCRIPT
 sudo apt-get -y update
 sudo apt-get -y install curl
+gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
 curl -sSL https://get.rvm.io | bash -s stable
 . ~/.bashrc
 . ~/.bash_profile

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ rvm --default use 2.0.0
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "hashicorp/precise64"
   config.vm.network "private_network", ip: "33.33.33.10"
   config.vm.provision "shell", inline: $script, privileged: false
 end


### PR DESCRIPTION
This makes 2 minor updates to the Vagrantfile.

Previously, vagrant was unable to import the box `precise64`, because it is now namespaced as `hashicorp/precise64`. The second issue being that RVM was failing to install during the provision.