### PR TITLE
Fixes broken image on Packer in Atlas blog post.

### DIFF
--- a/source/blog/2015-04-16-atlas-packer-vagrant.html.markdown
+++ b/source/blog/2015-04-16-atlas-packer-vagrant.html.markdown
@@ -46,7 +46,7 @@ of your template and associated configuration files,
 Atlas will automatically run Packer to build and provision the Vagrant box, and then
 post-process the resulting box to store it in Atlas.
 
-![Packer push](images/blog/atlas-packer/packer_push.png)
+![Packer push](/images/blog/atlas-packer/packer_push.png)
 
 Packer push allows users – in a single step – to modify base configuration
 and provisiong scripts to make new Vagrant box versions. Vagrant boxes can be


### PR DESCRIPTION
The "Packer push" image is busted on the _Packer in Atlas_ blog post. I'm not sure how the production web build works, but it looks like the path didn't match so it didn't sub in the versioned image suffix hash thing; it just left the raw image path in there. It works locally either way so it's hard to test, but this format matches the working images from the same blog post.