### PR TITLE
Add pagination to blog

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -14,6 +14,9 @@ activate :blog do |blog|
   blog.permalink = ":title.html"
   blog.prefix = "blog"
   blog.tag_template = "tag_template.html"
+
+  blog.paginate = true
+  blog.per_page = 5
 end
 
 # Build-specific configuration

--- a/source/blog.html.erb
+++ b/source/blog.html.erb
@@ -2,12 +2,12 @@
 page_title: Blog
 title: Blog
 layout: blog
+pageable: true
 ---
 
 <div class="container">
 	<div class="col-md-11">
-		<% blog.articles.each_index do |i| %>
-		<% article = blog.articles[i] %>
+		<% page_articles.each do |article| %>
 		<article class="right-aligned">
 			<div class="row">
 				<!-- post summary content -->
@@ -23,6 +23,15 @@ layout: blog
 				</div>	<!-- span -->
 			</div>	<!-- row -->
 		</article>
+		<% end %>
+	</div>
+
+	<div class="col-md-11" style="padding: 3em 0; text-align: center;">
+		<% if prev_page %>
+			<%= link_to "Previous Page", prev_page.url, class: "hbtn outline-btn black small" %>
+		<% end %>
+		<% if next_page %>
+			<%= link_to "Next Page", next_page.url, class: "hbtn outline-btn black small" %>
 		<% end %>
 	</div>
 </div> <!-- container -->


### PR DESCRIPTION
This adds very basic pagination to the blog (5 per page). We have a lot of blog posts now and it is taking the page a very long time to load. To make our mobile viewers happy (and just to have a better experience), this adds pagination to the blog.