### PR TITLE
Update custom provider example in blog post

### DIFF
--- a/source/blog/2014-09-26-terraform-custom-providers.html.markdown
+++ b/source/blog/2014-09-26-terraform-custom-providers.html.markdown
@@ -83,7 +83,11 @@ import (
 )
 
 func main() {
-	plugin.Serve(Provider())
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: func() terraform.ResourceProvider {
+			return Provider()
+		},
+	})
 }
 </pre>
 


### PR DESCRIPTION
This commit updates the code in the `main` function of the provider example to use `ServeOpts` rather than calling Provider() directly - the current version does not compile.