### PR TITLE
Switch 'Products' and 'Atlas' in header

### DIFF
--- a/source/layouts/_header.erb
+++ b/source/layouts/_header.erb
@@ -22,8 +22,8 @@
             </ul>
             <ul class="main-links nav navbar-nav navbar-right">
               <li class=""><a href="/about.html">About</a></li>
-              <li class="first"><a href="<%= "#products" if current_page.path.include?("index.html") %><%= "/index.html#products" if ( ! current_page.path.include?("index.html")) %>">Products</a></li>
               <li class=""><a href="/atlas.html">Atlas</a></li>
+              <li class="first"><a href="<%= "#products" if current_page.path.include?("index.html") %><%= "/index.html#products" if ( ! current_page.path.include?("index.html")) %>">Products</a></li>
               <li class=""><a href="/blog.html">Blog</a></li>
               <li class=""><a href="/partners.html">Partners</a></li>
               <li class=""><a href="/jobs.html">Jobs</a></li>


### PR DESCRIPTION
This switches the order of 'Products' and 'Atlas' in the header, so that the links match the page order.