### PR TITLE
rounding fix for safari

### DIFF
--- a/source/stylesheets/scss/components/_atlas-highlights.scss
+++ b/source/stylesheets/scss/components/_atlas-highlights.scss
@@ -51,7 +51,7 @@
 
     .atlas-highlights-item{
       position: relative;
-      width: 50%;
+      width: 49.5%;
       padding-left: 110px;
       padding-right: 70px;
       box-sizing: border-box;


### PR DESCRIPTION
Tiny tweak to fix the layout of highlight items in safari:

before
<img width="1092" alt="screen shot 2015-12-22 at 9 30 31 am" src="https://cloud.githubusercontent.com/assets/39469/11958695/e090afc0-a88e-11e5-86e5-34a1667b3603.png">


after
<img width="1261" alt="screen shot 2015-12-22 at 9 30 07 am" src="https://cloud.githubusercontent.com/assets/39469/11958700/e735702c-a88e-11e5-8ba4-cd649e6c45e5.png">
