### PR TITLE
Keep stripe customer logo in aspect ratio

### DIFF
--- a/source/stylesheets/scss/components/_customers.scss
+++ b/source/stylesheets/scss/components/_customers.scss
@@ -60,7 +60,7 @@
       @include img-retina( '../images/v2/customers/customer-capitolone', png, 144px, 52px);
     }
     &.stripe{
-      @include img-retina( '../images/v2/customers/customer-stripe', png, 144px, 39px);
+      @include img-retina( '../images/v2/customers/customer-stripe', png, 104px, 43px);
     }
     &.pinterest{
       @include img-retina( '../images/v2/customers/customer-pinterest', png, 144px, 37px);


### PR DESCRIPTION
Problem
------------
Stripe logo looks a bit too wide on production

Solution
-----------
Keep aspect ratio align with other company sizes
<img width="963" alt="screen shot 2015-12-29 at 10 42 30 pm" src="https://cloud.githubusercontent.com/assets/3615935/12059497/31e2bc32-af11-11e5-8112-57c447153207.png">

